### PR TITLE
Script for generating concept trie pickle, plus the pickled trie

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,3 +4,4 @@
 *model.trainables.syn1neg.npy filter=lfs diff=lfs merge=lfs -text
 *.wordvectors filter=lfs diff=lfs merge=lfs -text
 *.wordvectors.vectors.npy filter=lfs diff=lfs merge=lfs -text
+concept_trie.pkl filter=lfs diff=lfs merge=lfs -text

--- a/concept_trie.pkl
+++ b/concept_trie.pkl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7f0abfacfc24d76b50e0d51dfcec7b72ee19f9dc10fa6f20b31e15ff8a9af36e
+size 801485300

--- a/concept_trie_pickle.py
+++ b/concept_trie_pickle.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python
+
+import pickle
+import lzma
+from csv import DictReader
+from pathlib import Path
+
+from tqdm import tqdm
+from pygtrie import CharTrie
+
+# the root for the word-lapse-models datafiles
+data_folder = Path("./")
+
+# the number of concept map items, determined by unzipping all_concept_ids.tsv.xz
+# and counting the number of lines (-1 for the header)
+# (this is used to display a progress bar with an estimate of the processing time)
+APPROX_CONCEPT_LINES = 39446071
+
+def get_concept_lines():
+    with lzma.open(data_folder / Path("all_concept_ids.tsv.xz"), "rt") as fp:
+        reader = DictReader(
+            fp, dialect="excel-tab", fieldnames=("concept_id", "concept")
+        )
+        for row in reader:
+            yield row
+
+def create_concept_trie():
+    concept_trie_pickle = data_folder / Path("concept_trie.pkl")
+
+    print("regenerating concept trie (this will take a while)...")
+    concept_trie = CharTrie()
+    for row in tqdm(get_concept_lines(), total=APPROX_CONCEPT_LINES):
+        concept_trie[row["concept"]] = row["concept_id"]
+
+    print("...writing pickle...")
+    with open(concept_trie_pickle, "wb") as fp:
+        pickle.dump(concept_trie, fp)
+    print("...done!")
+
+if __name__ == '__main__':
+    create_concept_trie()

--- a/concept_trie_pickle.py
+++ b/concept_trie_pickle.py
@@ -14,7 +14,7 @@ data_folder = Path("./")
 # the number of concept map items, determined by unzipping all_concept_ids.tsv.xz
 # and counting the number of lines (-1 for the header)
 # (this is used to display a progress bar with an estimate of the processing time)
-APPROX_CONCEPT_LINES = 39446071
+APPROX_CONCEPT_LINES = 39446070
 
 def get_concept_lines():
     with lzma.open(data_folder / Path("all_concept_ids.tsv.xz"), "rt") as fp:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 gensim==4.1.2
 numpy==1.21.5
-pkg_resources==0.0.0
 scipy==1.7.3
 smart-open==5.2.1
+pygtrie==2.4.2
+tqdm==4.64.0


### PR DESCRIPTION
This PR complements the word-lapse PR https://github.com/greenelab/word-lapse/pull/42, which adds support to the API server's `/autocomplete` endpoint for querying the concept map by label. Specifically, this PR adds a script for generating the concept trie pickle, and includes the output of running that script as `concept_trie.pkl`.